### PR TITLE
Bugfix, `outdir` declaration

### DIFF
--- a/interface/model/clm5_0/enkf_clm_mod_5.F90
+++ b/interface/model/clm5_0/enkf_clm_mod_5.F90
@@ -64,7 +64,7 @@ module enkf_clm_mod
   real(r8) :: dtime     ! time step increment (sec)
   integer  :: ier       ! error code
 
-  character(kind=c_char,len=100),bind(C,name="outdir"),target :: outdir
+  character(kind=c_char),dimension(100),bind(C,name="outdir"),target :: outdir
 
   logical  :: log_print    ! true=> print diagnostics
   real(r8) :: eccf         ! earth orbit eccentricity factor

--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -64,7 +64,7 @@ module enkf_clm_mod
   real(r8) :: dtime     ! time step increment (sec)
   integer  :: ier       ! error code
 
-  character(kind=c_char,len=100),bind(C,name="outdir"),target :: outdir
+  character(kind=c_char),dimension(100),bind(C,name="outdir"),target :: outdir
 
   logical  :: log_print    ! true=> print diagnostics
   real(r8) :: eccf         ! earth orbit eccentricity factor


### PR DESCRIPTION
Error message.

```
Error: BIND(C) Variable ‘outdir’ at (1) must have length one
```

Related to https://github.com/HPSCTerrSys/TSMP2/pull/61