### PR TITLE
Remove deprecated index array obs_id_p

### DIFF
--- a/interface/framework/g2l_obs_pdaf.F90
+++ b/interface/framework/g2l_obs_pdaf.F90
@@ -54,7 +54,7 @@ SUBROUTINE g2l_obs_pdaf(domain_p, step, dim_obs_f, dim_obs_l, mstate_f, &
 !
 ! !USES:
   USE mod_assimilation, &
-       ONLY: obs_index_l, obs_nc2pdaf_deprecated
+       ONLY: obs_index_l, obs_nc2pdaf
 
   IMPLICIT NONE
 
@@ -86,11 +86,11 @@ SUBROUTINE g2l_obs_pdaf(domain_p, step, dim_obs_f, dim_obs_l, mstate_f, &
   mstate_l(:) = 0.0
 
   ! Set Obs. vector on local domain
-  ! Index array OBS_NC2PDAF_DEPRECATED set in subroutine OBS_OP_F_PDAF
+  ! Index array OBS_NC2PDAF set in subroutine INIT_DIM_OBS_F_PDAF
   ! Index array OBS_INDEX_L (returns nc-ordered index) set in subroutine INIT_DIM_OBS_L_PDAF
   do i=1,dim_obs_l
     !mstate_l(i) = mstate_f(obs_index_l(i))
-    mstate_l(i) = mstate_f(obs_nc2pdaf_deprecated(obs_index_l(i)))
+    mstate_l(i) = mstate_f(obs_nc2pdaf(obs_index_l(i)))
   end do
 
 END SUBROUTINE g2l_obs_pdaf

--- a/interface/framework/init_dim_obs_f_pdaf.F90
+++ b/interface/framework/init_dim_obs_f_pdaf.F90
@@ -73,8 +73,7 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
        obs_pdaf2nc, &
        local_dims_obs, &
        local_disp_obs, &
-       dim_obs_p, &
-       obs_id_p
+       dim_obs_p
 #ifndef PARFLOW_STAND_ALONE
 #ifndef OBS_ONLY_PARFLOW
 !hcp
@@ -443,23 +442,16 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
 
   ! Number of observations in process-local domain
   ! ----------------------------------------------
-  ! Additionally `obs_id_p` is set (the NetCDF index of the
-  ! observation corresponding to the state index in the local domain)
   dim_obs_p = 0
 
 #ifndef CLMSA
 #ifndef OBS_ONLY_CLM
   if (model == tag_model_parflow) then
 
-     if(allocated(obs_id_p)) deallocate(obs_id_p)
-     allocate(obs_id_p(enkf_subvecsize))
-     obs_id_p(:) = 0
-
      do i = 1, dim_obs
         do j = 1, enkf_subvecsize
            if (idx_obs_nc(i) == idx_map_subvec2state_fortran(j)) then
               dim_obs_p = dim_obs_p + 1
-              obs_id_p(j) = i
            end if
         end do
      end do
@@ -475,10 +467,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
   is_use_dr = .true.
 
   if(model == tag_model_clm) then
-
-     if(allocated(obs_id_p)) deallocate(obs_id_p)
-     allocate(obs_id_p(endg-begg+1))
-     obs_id_p(:) = 0
 
      do i = 1, dim_obs
         cnt = 1
@@ -496,7 +484,6 @@ SUBROUTINE init_dim_obs_f_pdaf(step, dim_obs_f)
             if(((is_use_dr).and.(deltax<=clmobs_dr(1)).and.(deltay<=clmobs_dr(2))).or. &
               ((.not. is_use_dr).and.(longxy_obs(i) == longxy(cnt)) .and. (latixy_obs(i) == latixy(cnt)))) then
                 dim_obs_p = dim_obs_p + 1
-                obs_id_p(cnt) = i
 
                 ! if (is_use_dr) then
                 !   call GetGlobalWrite(g,nameg)

--- a/interface/framework/init_dim_obs_pdaf.F90
+++ b/interface/framework/init_dim_obs_pdaf.F90
@@ -68,9 +68,8 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
        pressure_obserr_p, clm_obserr_p, &
        obs_pdaf2nc, &
        local_dims_obs, &
-       local_disp_obs, &
+       local_disp_obs
        ! dim_obs_p, &
-       obs_id_p
 #ifndef PARFLOW_STAND_ALONE
 #ifndef OBS_ONLY_PARFLOW
 !hcp
@@ -439,23 +438,16 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
 
   ! Number of observations in process-local domain
   ! ----------------------------------------------
-  ! Additionally `obs_id_p` is set (the NetCDF index of the
-  ! observation corresponding to the state index in the local domain)
   dim_obs_p = 0
 
 #ifndef CLMSA
 #ifndef OBS_ONLY_CLM
   if (model == tag_model_parflow) then
 
-     if(allocated(obs_id_p)) deallocate(obs_id_p)
-     allocate(obs_id_p(enkf_subvecsize))
-     obs_id_p(:) = 0
-
      do i = 1, dim_obs
         do j = 1, enkf_subvecsize
            if (idx_obs_nc(i) == idx_map_subvec2state_fortran(j)) then
               dim_obs_p = dim_obs_p + 1
-              obs_id_p(j) = i
            end if
         end do
      end do
@@ -471,10 +463,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
   is_use_dr = .true.
 
   if(model == tag_model_clm) then
-
-     if(allocated(obs_id_p)) deallocate(obs_id_p)
-     allocate(obs_id_p(endg-begg+1))
-     obs_id_p(:) = 0
 
      do i = 1, dim_obs
         cnt = 1
@@ -492,7 +480,6 @@ SUBROUTINE init_dim_obs_pdaf(step, dim_obs_p)
             if(((is_use_dr).and.(deltax<=clmobs_dr(1)).and.(deltay<=clmobs_dr(2))).or. &
               ((.not. is_use_dr).and.(longxy_obs(i) == longxy(cnt)) .and. (latixy_obs(i) == latixy(cnt)))) then
                 dim_obs_p = dim_obs_p + 1
-                obs_id_p(cnt) = i
 
                 ! if (is_use_dr) then
                 !   call GetGlobalWrite(g,nameg)

--- a/interface/framework/mod_assimilation.F90
+++ b/interface/framework/mod_assimilation.F90
@@ -93,8 +93,6 @@ MODULE mod_assimilation
   INTEGER, ALLOCATABLE :: var_id_obs(:)   ! for remote sensing data the variable identifier to group
                                           ! variables distributed over a grid surface area
   !kuw
-  INTEGER, ALLOCATABLE :: obs_id_p(:) ! ID of observation point in PE-local domain
-  INTEGER, ALLOCATABLE :: obs_nc2pdaf_deprecated(:)   ! index for mapping mstate to local domain
   INTEGER, ALLOCATABLE :: obs_nc2pdaf(:)   ! index for mapping mstate to local domain
   !kuw end
 

--- a/interface/framework/obs_op_f_pdaf.F90
+++ b/interface/framework/obs_op_f_pdaf.F90
@@ -56,13 +56,10 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   ! Later revisions - see svn log
   !
   ! !USES:
-  USE mpi, ONLY: MPI_DOUBLE
   USE mpi, ONLY: MPI_DOUBLE_PRECISION
-  USE mpi, ONLY: MPI_INT
-  USE mpi, ONLY: MPI_SUM
   USE mpi, ONLY: MPI_ALLGATHERV
   USE mod_assimilation, &
-       ONLY: obs_index_p, local_dims_obs, local_disp_obs, obs_id_p, obs_nc2pdaf_deprecated, &
+       ONLY: obs_index_p, local_dims_obs, local_disp_obs, &
        var_id_obs, dim_obs_p
   USE mod_assimilation, ONLY: obs_pdaf2nc
   USE mod_assimilation, ONLY: obs_nc2pdaf
@@ -91,8 +88,6 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   INTEGER :: ierror, max_var_id
   INTEGER :: i                         ! Counter
   REAL, ALLOCATABLE :: m_state_tmp(:)  ! Temporary process-local state vector
-  INTEGER, ALLOCATABLE :: obs_nc2pdaf_deprecated_p_tmp(:)
-  INTEGER, ALLOCATABLE :: obs_nc2pdaf_deprecated_tmp(:)
 
   ! *********************************************
   ! *** Perform application of measurement    ***
@@ -110,16 +105,9 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
 
   ! Initialize process-local observed state
   ALLOCATE(m_state_tmp(dim_obs_p))
-  allocate(obs_nc2pdaf_deprecated_p_tmp (dim_obs_p))
-
-  if(allocated(obs_nc2pdaf_deprecated)) deallocate(obs_nc2pdaf_deprecated)
-  allocate(obs_nc2pdaf_deprecated(dim_obs_f))
-  if(allocated(obs_nc2pdaf_deprecated_tmp)) deallocate(obs_nc2pdaf_deprecated_tmp)
-  allocate(obs_nc2pdaf_deprecated_tmp(dim_obs_f))
 
   DO i = 1, dim_obs_p
      m_state_tmp(i) = state_p(obs_index_p(i))
-     obs_nc2pdaf_deprecated_p_tmp(i)  = obs_id_p(obs_index_p(i))
   END DO
 
   !print *,'local_dims_obs(mype_filter+1) ', local_dims_obs(mype_filter+1)
@@ -131,48 +119,5 @@ SUBROUTINE obs_op_f_pdaf(step, dim_p, dim_obs_f, state_p, m_state_f)
   CALL mpi_allgatherv(m_state_tmp, dim_obs_p, &
        MPI_DOUBLE_PRECISION, m_state_f, local_dims_obs, local_disp_obs, &
        MPI_DOUBLE_PRECISION, comm_filter, ierror)
-
-  ! gather obs_nc2pdaf_deprecated_p
-  CALL mpi_allgatherv(obs_nc2pdaf_deprecated_p_tmp, dim_obs_p, &
-       MPI_INT, obs_nc2pdaf_deprecated, local_dims_obs, local_disp_obs, &
-       MPI_INT, comm_filter, ierror)
-
-  ! At this point OBS_NC2PDAF_DEPRECATED should be the same as OBS_PDAF2NC from
-  ! INIT_DIM_OBS_PDAF / INIT_DIM_OBS_F_PDAF
-  do i = 1, dim_obs_f
-    if(.not. obs_nc2pdaf_deprecated(i) == obs_pdaf2nc(i)) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR in observation index arrays"
-      print *, "i=", i
-      print *, "obs_nc2pdaf_deprecated(i)=", obs_nc2pdaf_deprecated(i)
-      print *, "obs_pdaf2nc(i)=", obs_pdaf2nc(i)
-      call abort_parallel()
-    end if
-  end do
-
-  ! Then OBS_NC2PDAF_DEPRECATED is inverted in the following lines
-
-  ! resort obs_nc2pdaf_deprecated_p
-  do i=1,dim_obs_f
-     obs_nc2pdaf_deprecated_tmp(i) = obs_nc2pdaf_deprecated(i)
-  enddo
-  do i=1,dim_obs_f
-    ! print *,'obs_nc2pdaf_deprecated_tmp(i) ', obs_nc2pdaf_deprecated_tmp(i)
-     obs_nc2pdaf_deprecated(obs_nc2pdaf_deprecated_tmp(i)) = i
-  enddo
-
-  ! At this point OBS_NC2PDAF_DEPRECATED should be the same as OBS_NC2PDAF from
-  ! INIT_DIM_OBS_PDAF / INIT_DIM_OBS_F_PDAF
-  do i = 1, dim_obs_f
-    if(.not. obs_nc2pdaf_deprecated(i) == obs_nc2pdaf(i)) then
-      print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR in observation index arrays"
-      print *, "i=", i
-      print *, "obs_nc2pdaf_deprecated(i)=", obs_nc2pdaf_deprecated(i)
-      print *, "obs_nc2pdaf(i)=", obs_nc2pdaf(i)
-      call abort_parallel()
-    end if
-  end do
-
-  ! Clean up
-  DEALLOCATE(m_state_tmp,obs_nc2pdaf_deprecated_p_tmp,obs_nc2pdaf_deprecated_tmp)
 
 END SUBROUTINE obs_op_f_pdaf


### PR DESCRIPTION
This index array was only used to generate deprecated copies of
`obs_nc2pdaf`, which have now also been removed.