### PR TITLE
.gitignore: Ignore build artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+include/*.mod
+interface/framework/*.mod
+interface/framework/*.o
+interface/model/*.mod
+interface/model/*.o
+lib/lib*
+src/*.mod
+src/*.o


### PR DESCRIPTION
Problem: Building TSMP2-PDAF, the PDAF-submodule of TSMP2 shows modifications coming from untracked build artefacts:

- `*.mod` Module files
- `*.o` Object files
- library files