### PR TITLE
Change default t_printensemble to disable debug output

### DIFF
--- a/docs/users_guide/running_tsmp_pdaf/input_enkfpf.md
+++ b/docs/users_guide/running_tsmp_pdaf/input_enkfpf.md
@@ -357,8 +357,10 @@ containing the pre-DA state ensemble is `integrate`.
 `PF:t_printensemble`: (integer) The timestep for the state ensemble
 output switched on under `PF:printensemble`.
 
-Default setting is `-1`, which means: Print debug output at every DA
+Another setting is `-1`, which means: Print debug output at every DA
 time step.
+
+Default setting is `-2`, which means: No additional debug output.
 
 ### PF:printstat ###
 
@@ -568,8 +570,10 @@ Layers](https://escomp.github.io/ctsm-docs/versions/master/html/tech_note/Ecosys
 `CLM:t_printensemble`: (integer) The timestep for the state ensemble
 output switched on with the debug flag `PDAF_DEBUG`.
 
-Default setting is `-1`, which means: Print debug output at every DA
+Another setting is `-1`, which means: Print debug output at every DA
 time step.
+
+Default setting is `-2`, which means: No additional debug output.
 
 ### CLM:watmin_switch ###
 
@@ -877,7 +881,7 @@ Default: 0, output turned off.
  |           | `aniso_use_parflow`     | 0             |
  |           |                         |               |
  |           | `printensemble`         | 1             |
- |           | `t_printensemble`       | -1            |
+ |           | `t_printensemble`       | -2            |
  |           | `printstat`             | 1             |
  |           | `paramprintensemble`    | 1             |
  |           | `paramprintstat`        | 1             |
@@ -894,7 +898,7 @@ Default: 0, output turned off.
  |           | `statevec_colmean`      | 0             |
  |           | `statevec_only_active`  | 0             |
  |           | `statevec_max_layer`    | 25            |
- |           | `t_printensemble`       | -1            |
+ |           | `t_printensemble`       | -2            |
  |           | `watmin_switch`         | 0             |
  | `[COSMO]` |                         |               |
  |           | `nprocs`                | 0             |

--- a/interface/model/clm3_5/enkf_clm_mod.F90
+++ b/interface/model/clm3_5/enkf_clm_mod.F90
@@ -206,7 +206,7 @@ module enkf_clm_mod
     ttlai => clm3%g%l%c%p%pps%tlai  !hcp
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble == -1) THEN
 
       IF(clmupdate_swc.NE.0) THEN
         ! TSMP-PDAF: Debug output of CLM swc
@@ -290,7 +290,7 @@ module enkf_clm_mod
     endif
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble == -1) THEN
       ! TSMP-PDAF: For debug runs, output the state vector in files
       WRITE(fn, "(a,i5.5,a,i5.5,a)") "clmstate_", mype, ".integrate.", tstartcycle + 1, ".txt"
       OPEN(unit=71, file=fn, action="write")
@@ -341,7 +341,7 @@ module enkf_clm_mod
     logical :: swc_zero_before_update = .false.
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble == -1) THEN
       ! TSMP-PDAF: For debug runs, output the state vector in files
       WRITE(fn, "(a,i5.5,a,i5.5,a)") "clmstate_", mype, ".update.", tstartcycle, ".txt"
       OPEN(unit=71, file=fn, action="write")
@@ -364,7 +364,7 @@ module enkf_clm_mod
     h2osoi_ice    => clm3%g%l%c%cws%h2osoi_ice
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble == -1) THEN
 
       IF(clmupdate_swc.NE.0) THEN
         ! TSMP-PDAF: For debug runs, output the state vector in files
@@ -476,7 +476,7 @@ module enkf_clm_mod
         end do
 
 #ifdef PDAF_DEBUG
-        IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble < 0) THEN
+        IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble == -1) THEN
 
           IF(clmupdate_swc.NE.0) THEN
             ! TSMP-PDAF: For debug runs, output the state vector in files

--- a/interface/model/common/read_enkfpar.c
+++ b/interface/model/common/read_enkfpar.c
@@ -53,7 +53,7 @@ void read_enkfpar(char *parname)
   pf_aniso_perm_z       = iniparser_getdouble(pardict,"PF:aniso_perm_z",1);
   pf_aniso_use_parflow  = iniparser_getint(pardict,"PF:aniso_use_parflow",0);
   pf_printensemble      = iniparser_getint(pardict,"PF:printensemble",1);
-  pf_t_printensemble    = iniparser_getint(pardict,"PF:t_printensemble",-1);
+  pf_t_printensemble    = iniparser_getint(pardict,"PF:t_printensemble",-2);
   pf_printstat          = iniparser_getint(pardict,"PF:printstat",1);
   pf_paramprintensemble = iniparser_getint(pardict,"PF:paramprintensemble",1);
   pf_paramprintstat     = iniparser_getint(pardict,"PF:paramprintstat",1);
@@ -85,7 +85,7 @@ void read_enkfpar(char *parname)
   clmstatevec_colmean   = iniparser_getint(pardict,"CLM:statevec_colmean",0);
   clmstatevec_only_active = iniparser_getint(pardict,"CLM:statevec_only_active",0);
   clmstatevec_max_layer = iniparser_getint(pardict,"CLM:statevec_max_layer",25);
-  clmt_printensemble    = iniparser_getint(pardict,"CLM:t_printensemble",-1);
+  clmt_printensemble    = iniparser_getint(pardict,"CLM:t_printensemble",-2);
   clmwatmin_switch      = iniparser_getint(pardict,"CLM:watmin_switch",0);
   clmswc_mask_snow      = iniparser_getint(pardict,"CLM:swc_mask_snow",0);
 

--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -408,7 +408,7 @@ module enkf_clm_mod
     porgm => soilstate_inst%cellorg_col
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble == -1) THEN
 
       IF(clmupdate_swc/=0) THEN
         ! TSMP-PDAF: Debug output of CLM swc
@@ -458,7 +458,7 @@ module enkf_clm_mod
     endif
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle + 1 .OR. clmt_printensemble == -1) THEN
       ! TSMP-PDAF: For debug runs, output the state vector in files
       WRITE(fn, "(a,i5.5,a,i5.5,a)") "clmstate_", mype, ".integrate.", tstartcycle + 1, ".txt"
       OPEN(unit=71, file=fn, action="write")
@@ -560,7 +560,7 @@ module enkf_clm_mod
     swc_zero_before_update = .false.
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble == -1) THEN
       ! TSMP-PDAF: For debug runs, output the state vector in files
       WRITE(fn, "(a,i5.5,a,i5.5,a)") "clmstate_", mype, ".update.", tstartcycle, ".txt"
       OPEN(unit=71, file=fn, action="write")
@@ -575,7 +575,7 @@ module enkf_clm_mod
     h2osoi_ice    => waterstate_inst%h2osoi_ice_col
 
 #ifdef PDAF_DEBUG
-    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble < 0) THEN
+    IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble == -1) THEN
 
       IF(clmupdate_swc/=0) THEN
         ! TSMP-PDAF: For debug runs, output the state vector in files
@@ -774,7 +774,7 @@ module enkf_clm_mod
         end do
 
 #ifdef PDAF_DEBUG
-        IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble < 0) THEN
+        IF(clmt_printensemble == tstartcycle .OR. clmt_printensemble == -1) THEN
 
             ! TSMP-PDAF: For debug runs, output the state vector in files
             WRITE(fn3, "(a,i5.5,a,i5.5,a)") "h2osoi_liq", mype, ".update.", tstartcycle, ".txt"

--- a/interface/model/parflow/enkf_parflow.c
+++ b/interface/model/parflow/enkf_parflow.c
@@ -625,7 +625,7 @@ void enkfparflowadvance(int tcycle, double current_time, double dt)
 	     added to `tstartcycle` in the wrapper subroutine directly
 	     after this routine, so the added value fits better than
 	     the current value. */
-	  if(pf_t_printensemble == tstartcycle + 1 || pf_t_printensemble < 0 ) {
+	  if(pf_t_printensemble == tstartcycle + 1 || pf_t_printensemble == -1 ) {
 	    if(pf_printensemble == 1) {
 	      enkf_printstatistics_pfb(&pf_statevec[0],"integrate",tstartcycle + 1 + stat_dumpoffset,pfoutfile_ens,3);
 	    }
@@ -1485,7 +1485,7 @@ void update_parflow () {
   }
 
   /* print updated ensemble */
-  if(pf_t_printensemble == tstartcycle || pf_t_printensemble < 0 ) {
+  if(pf_t_printensemble == tstartcycle || pf_t_printensemble == -1 ) {
     if(pf_updateflag == 3){
       if(pf_printensemble == 1) enkf_printstatistics_pfb(&pf_statevec[enkf_subvecsize],"update",tstartcycle + stat_dumpoffset,pfoutfile_ens,3);
     }else{


### PR DESCRIPTION
Previously, `t_printensemble` defaulted to `-1`, which triggered debug output at every DA time step. The debug condition checked for any negative value (`< 0`), making debug output enabled by default.

This commit changes the default of `t_printensemble` to `-2` (no debug output) and updates the condition to explicitly check for -1.

Debug output must now be explicitly enabled by setting `t_printensemble=-1` in `enkfpf.par`.

Commit message checked after generation with [Claude Code](https://claude.com/claude-code)