### PR TITLE
Fix for memory issue

### DIFF
--- a/interface/framework/callback_obs_pdafomi.F90
+++ b/interface/framework/callback_obs_pdafomi.F90
@@ -316,4 +316,17 @@
 
   END SUBROUTINE prodRinvA_l_pdafomi
 
+  SUBROUTINE deallocate_obs_pdafomi()
+
+    use obs_GRACE_pdafomi, ONLY: deallocate_obs_GRACE
+    use obs_SM_pdafomi, ONLY: deallocate_obs_SM
+
+    implicit none
+
+    CALL deallocate_obs_GRACE()
+    CALL deallocate_obs_SM()
+    !CALL deallocate_obs_C()
+
+  END SUBROUTINE deallocate_obs_pdafomi
+
 #endif

--- a/interface/framework/mod_read_obs.F90
+++ b/interface/framework/mod_read_obs.F90
@@ -90,6 +90,7 @@ contains
     use netcdf, only: nf90_inq_varid
     use netcdf, only: nf90_noerr
     use netcdf, only: nf90_get_var
+    use netcdf, only: nf90_close
     use mod_assimilation, only: screen
     implicit none
 
@@ -225,6 +226,8 @@ contains
             dim_obs_g = dim_obs
 
         end if
+
+        call check( nf90_close(ncid) )
 
     end if
 

--- a/interface/framework/obs_GRACE_pdafomi.F90
+++ b/interface/framework/obs_GRACE_pdafomi.F90
@@ -1359,7 +1359,6 @@ MODULE obs_GRACE_pdafomi
         end if
         call PDAFomi_deallocate_obs(thisobs)
 
-        ! deallocate also local observation arrays --> this should be done in PDAF but the error persists for the LESTKF while it is not there for the EnKF
         if (allocated(thisobs_l%id_obs_l)) deallocate(thisobs_l%id_obs_l)
         if (allocated(thisobs_l%ivar_obs_l)) deallocate(thisobs_l%ivar_obs_l)
         if (allocated(thisobs_l%distance_l)) deallocate(thisobs_l%distance_l)

--- a/interface/framework/obs_GRACE_pdafomi.F90
+++ b/interface/framework/obs_GRACE_pdafomi.F90
@@ -309,6 +309,10 @@ MODULE obs_GRACE_pdafomi
                     trim(current_observation_filename)
         end if
         dim_obs_p = 0
+        if (allocated(obs_p)) deallocate(obs_p)
+        if (allocated(ivar_obs_p)) deallocate(ivar_obs_p)
+        if (allocated(ocoord_p)) deallocate(ocoord_p)
+        if (allocated(thisobs%id_obs_p)) deallocate(thisobs%id_obs_p)
         ALLOCATE(obs_p(1))
         ALLOCATE(ivar_obs_p(1))
         ALLOCATE(ocoord_p(2, 1))
@@ -316,6 +320,8 @@ MODULE obs_GRACE_pdafomi
         thisobs%infile=0
         CALL PDAFomi_gather_obs(thisobs, dim_obs_p, obs_p, ivar_obs_p, ocoord_p, &
            thisobs%ncoord, cradius_GRACE, dim_obs)
+        DEALLOCATE(obs_g)
+        DEALLOCATE(obs_p, ocoord_p, ivar_obs_p)
         return
       end if
       thisobs%infile=1
@@ -1339,6 +1345,35 @@ MODULE obs_GRACE_pdafomi
         call check( nf90_close(ncid) )
 
     end subroutine read_temp_mean_model
+
+
+    subroutine deallocate_obs_GRACE()
+
+        USE PDAFomi, ONLY: PDAFomi_deallocate_obs
+        USE PDAFomi_obs_l, ONLY: obs_l_all, firstobs
+
+        implicit none
+
+        if (mype_filter==0) then
+            WRITE (*,*) 'Deallocating observations type GRACE'
+        end if
+        call PDAFomi_deallocate_obs(thisobs)
+
+        ! deallocate also local observation arrays --> this should be done in PDAF but the error persists for the LESTKF while it is not there for the EnKF
+        if (allocated(thisobs_l%id_obs_l)) deallocate(thisobs_l%id_obs_l)
+        if (allocated(thisobs_l%ivar_obs_l)) deallocate(thisobs_l%ivar_obs_l)
+        if (allocated(thisobs_l%distance_l)) deallocate(thisobs_l%distance_l)
+        if (allocated(thisobs_l%cradius_l)) deallocate(thisobs_l%cradius_l)
+        if (allocated(thisobs_l%sradius_l)) deallocate(thisobs_l%sradius_l)
+        if (allocated(thisobs_l%dist_l_v)) deallocate(thisobs_l%dist_l_v)
+        if (allocated(thisobs_l%cradius)) deallocate(thisobs_l%cradius)
+        if (allocated(thisobs_l%sradius)) deallocate(thisobs_l%sradius)
+
+        if (allocated(obs_l_all)) deallocate(obs_l_all)
+
+        firstobs=0
+
+    end subroutine deallocate_obs_GRACE
 
   END MODULE obs_GRACE_pdafomi
 #endif

--- a/interface/framework/obs_SM_pdafomi.F90
+++ b/interface/framework/obs_SM_pdafomi.F90
@@ -1342,7 +1342,6 @@ MODULE obs_SM_pdafomi
         end if
         call PDAFomi_deallocate_obs(thisobs)
 
-        ! deallocate also local observation arrays --> this should be done in PDAF but the error persists for the LESTKF while it is not there for the EnKF
         if (allocated(thisobs_l%id_obs_l)) deallocate(thisobs_l%id_obs_l)
         if (allocated(thisobs_l%ivar_obs_l)) deallocate(thisobs_l%ivar_obs_l)
         if (allocated(thisobs_l%distance_l)) deallocate(thisobs_l%distance_l)

--- a/interface/framework/obs_SM_pdafomi.F90
+++ b/interface/framework/obs_SM_pdafomi.F90
@@ -332,7 +332,7 @@ MODULE obs_SM_pdafomi
         thisobs%infile=0
         CALL PDAFomi_gather_obs(thisobs, dim_obs_p, obs_p, ivar_obs_p, ocoord_p, &
            thisobs%ncoord, cradius_SM, dim_obs)
-        DEALLOCATE(obs_g)
+        if (mype_filter==0) DEALLOCATE(obs_g)
         DEALLOCATE(obs_p, ocoord_p, ivar_obs_p)
         return
       end if

--- a/interface/framework/obs_SM_pdafomi.F90
+++ b/interface/framework/obs_SM_pdafomi.F90
@@ -321,6 +321,10 @@ MODULE obs_SM_pdafomi
                     trim(current_observation_filename)
         end if
         dim_obs_p = 0
+        if (allocated(obs_p)) deallocate(obs_p)
+        if (allocated(ivar_obs_p)) deallocate(ivar_obs_p)
+        if (allocated(ocoord_p)) deallocate(ocoord_p)
+        if (allocated(thisobs%id_obs_p)) deallocate(thisobs%id_obs_p)
         ALLOCATE(obs_p(1))
         ALLOCATE(ivar_obs_p(1))
         ALLOCATE(ocoord_p(2, 1))
@@ -328,6 +332,8 @@ MODULE obs_SM_pdafomi
         thisobs%infile=0
         CALL PDAFomi_gather_obs(thisobs, dim_obs_p, obs_p, ivar_obs_p, ocoord_p, &
            thisobs%ncoord, cradius_SM, dim_obs)
+        DEALLOCATE(obs_g)
+        DEALLOCATE(obs_p, ocoord_p, ivar_obs_p)
         return
       end if
 
@@ -434,7 +440,18 @@ MODULE obs_SM_pdafomi
 
                   dim_obs_p = dim_obs_p + 1
                   ! Use index array for setting the correct state vector index in `obs_id_p`
-                  thisobs%id_obs_p(1,state_clm2pdaf_p(c,layer_obs(i))) = i
+
+
+                  ! id_obs_p has to be allocated but it is not really used when a self implemented observation operator is used. Else, the structure has to point for each observation
+                  ! on the state vector element that is used to predict that observation. The dimension is then not the number of gridcells but dim_obs
+                  ! Normally, this does not yield any error. But when the number of observations is larger than the process-local state vector size, the model will crash.
+                  ! This is caused by an internal check in the PDAFomi_obs_f script: IF (MAXVAL(thisobs%id_obs_p) > dim_p .AND. dim_obs_p>0)
+                  ! Here, I will just set the id_obs_p to 1, not to i to not cause this error for large observation dimensions
+                  ! Note that id_obs_p could be used correctly if an internal observation operator is used but in this case, it has to be allocated with dim_obs_p, so after this loop
+                  ! This could then be filled with the state vector element index used to predict each observation, for now I set this everywhere to 1.
+                  ! Note that I keep the initial implementation for GRACE as I use the obs_id_p there for the observation operator. But the number of observations is there usually pretty 
+                  ! low, so this should not make a problem
+                  thisobs%id_obs_p(1,state_clm2pdaf_p(c,layer_obs(i))) = 1
 
                   if (obs_snapped) then
                     print *, "TSMP-PDAF mype(w)=", mype_world, ": ERROR Observation snapped at multiple grid cells."
@@ -978,6 +995,7 @@ MODULE obs_SM_pdafomi
         else
           coords_l(1) = lon(state_loc2clm_c_p(domain_p))
         end if
+        coords_l(2) = lat(state_loc2clm_c_p(domain_p))
 
       else
 
@@ -1311,6 +1329,34 @@ MODULE obs_SM_pdafomi
         deallocate(weight)
 
     end subroutine prodRinvA_l_SM
+
+    subroutine deallocate_obs_SM()
+
+        USE PDAFomi, ONLY: PDAFomi_deallocate_obs
+        USE PDAFomi_obs_l, ONLY: obs_l_all, firstobs
+
+        implicit none
+
+        if (mype_filter==0) then
+            WRITE (*,*) 'Deallocating observations type SM'
+        end if
+        call PDAFomi_deallocate_obs(thisobs)
+
+        ! deallocate also local observation arrays --> this should be done in PDAF but the error persists for the LESTKF while it is not there for the EnKF
+        if (allocated(thisobs_l%id_obs_l)) deallocate(thisobs_l%id_obs_l)
+        if (allocated(thisobs_l%ivar_obs_l)) deallocate(thisobs_l%ivar_obs_l)
+        if (allocated(thisobs_l%distance_l)) deallocate(thisobs_l%distance_l)
+        if (allocated(thisobs_l%cradius_l)) deallocate(thisobs_l%cradius_l)
+        if (allocated(thisobs_l%sradius_l)) deallocate(thisobs_l%sradius_l)
+        if (allocated(thisobs_l%dist_l_v)) deallocate(thisobs_l%dist_l_v)
+        if (allocated(thisobs_l%cradius)) deallocate(thisobs_l%cradius)
+        if (allocated(thisobs_l%sradius)) deallocate(thisobs_l%sradius)
+
+        if (allocated(obs_l_all)) deallocate(obs_l_all)
+
+        firstobs=0
+
+    end subroutine deallocate_obs_SM
 
 
   END MODULE obs_SM_pdafomi

--- a/interface/framework/prepoststep_ens_pdaf.F90
+++ b/interface/framework/prepoststep_ens_pdaf.F90
@@ -75,8 +75,15 @@ SUBROUTINE prepoststep_ens_pdaf(step, dim_p, dim_ens, dim_ens_p, dim_obs_p, &
     use mod_tsmp, &
         only: tag_model_parflow, pf_statevecsize, nprocclm, model
 
+#ifdef CLMFIVE
+    USE mod_assimilation, ONLY: use_omi
+#endif
 
     IMPLICIT NONE
+
+#ifdef CLMFIVE
+    external :: deallocate_obs_pdafomi
+#endif
 
     ! !ARGUMENTS:
     INTEGER, INTENT(in) :: step        ! Current time step (negative for call after forecast)
@@ -103,6 +110,7 @@ SUBROUTINE prepoststep_ens_pdaf(step, dim_p, dim_ens, dim_ens_p, dim_obs_p, &
     INTEGER, SAVE :: allocflag = 0      ! Flag for memory counting
     LOGICAL, SAVE :: firstio = .TRUE.   ! File output is peformed for first time?
     LOGICAL, SAVE :: firsttime = .TRUE. ! Routine is called for first time?
+    LOGICAL, SAVE :: firsttime_omi = .TRUE. ! Routine is called for first time? --> for PDAF OMI, for backward compatibility if the statement in 1==2 should be used at one point
     REAL :: invdim_ens                  ! Inverse ensemble size
     REAL :: invdim_ensm1                ! Inverse of ensemble size minus 1
     REAL :: rmserror_est                ! estimated RMS error
@@ -264,4 +272,15 @@ SUBROUTINE prepoststep_ens_pdaf(step, dim_p, dim_ens, dim_ens_p, dim_obs_p, &
 
     firsttime = .FALSE.
     end if
+
+#ifdef CLMFIVE
+    OMI: IF (use_omi) THEN ! deallocate observation arrays for second call of prepoststep
+        if (firsttime_omi) then
+            firsttime_omi = .FALSE.
+        else
+            CALL deallocate_obs_pdafomi()
+            firsttime_omi = .TRUE.
+        end if
+    end if OMI
+#endif
 END SUBROUTINE prepoststep_ens_pdaf

--- a/interface/model/eclm/print_update_clm_5.F90
+++ b/interface/model/eclm/print_update_clm_5.F90
@@ -337,7 +337,7 @@ subroutine print_inc_clm() bind(C,name="print_inc_clm")
     status =  nf90_def_var(il_file_id, "SOILLIQ", NF90_FLOAT, dimids, ncvarid(1))
     status =  nf90_def_var(il_file_id, "SOILICE", NF90_FLOAT, dimids, ncvarid(2))
     status =  nf90_def_var(il_file_id, "H2OSNO", NF90_FLOAT, dimids_1level, ncvarid(3))
-    status =  nf90_def_var(il_file_id, "TWS", NF90_FLOAT, dimids_1level, ncvarid(3))
+    status =  nf90_def_var(il_file_id, "TWS", NF90_FLOAT, dimids_1level, ncvarid(4))
     status =  nf90_enddef(il_file_id)
   end if
 


### PR DESCRIPTION
Memory issue is partly fixed (https://github.com/HPSCTerrSys/pdaf/issues/41). The memory now rises much slower than before. Observation structures are deallocated at the end of each assimilation time step. For global arrays, OMI internal function is called, local arrays are deallocated manually. The functions are called in prepoststep with a flag to make sure they are called during the second call of prepoststep. Further changes:
- observation file is closed after loading --> contributed to memory issue
- minor bug fixes --> did not really had an effect on the current simulations bur are still fixed