### PR TITLE
Robustness guards for LSTDA

### DIFF
--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -955,7 +955,25 @@ module enkf_clm_mod
         if(n_p > 0) then
           clm_statevec(cc+(1+nlevgrnd)*clm_varsize) = clm_statevec(cc+(1+nlevgrnd)*clm_varsize) / real(n_p, r8)
         else
-          ! No vegetated patches: reuse TSKIN mean as safe fallback.
+          ! No vegetated patches in this gridcell (bare ground, glacier, lake):
+          ! t_veg retains spval (~1e36) for all patches, so no meaningful TVEG
+          ! average can be formed. TSKIN is used as a fallback to keep the value
+          ! physically plausible within the DA step.
+          !
+          ! Note: this slot does not affect the model state. The distribution
+          ! step guards against writing back to patches where t_veg >= 1e20
+          ! (see update_clm_statevec_T), so the fallback value is never applied.
+          !
+          ! The fallback does, however, participate in ensemble covariance
+          ! estimation during DA, introducing an artificial TSKIN-TVEG
+          ! correlation for these cells. A conceptually cleaner solution would
+          ! be to exclude non-vegetated gridcells from the TVEG part of the
+          ! state vector entirely (detectable at initialisation: all patches in
+          ! the gridcell have t_veg >= 1e20). This would require a mask array
+          ! and non-uniform state vector layout, breaking the current assumption
+          ! that every gridcell contributes the same variable block. The mapping
+          ! arrays state_pdaf2clm_p_p / state_clm2pdaf_p already handle
+          ! non-trivial patch mappings and could serve as a template for this.
           clm_statevec(cc+(1+nlevgrnd)*clm_varsize) = clm_statevec(cc)
         end if
 

--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -1428,6 +1428,7 @@ module enkf_clm_mod
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
             if (ieee_is_nan(increment_factor)) then
+              print *, "WARNING: t_skin increment_factor is NaN at p=", p, " - leaving t_skin unchanged"
               t_update = t_skin(p)
             else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_skin(p) + increment_factor
@@ -1456,6 +1457,7 @@ module enkf_clm_mod
             else
               increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
               if (ieee_is_nan(increment_factor)) then
+                print *, "WARNING: t_soisno increment_factor is NaN at c=", c, " lev=", lev, " - leaving t_soisno unchanged"
                 t_update = t_soisno(c,lev)
               else if (abs(increment_factor) < clmT_max_increment) then
                 t_update = t_soisno(c,lev) + increment_factor
@@ -1484,6 +1486,7 @@ module enkf_clm_mod
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
             if (ieee_is_nan(increment_factor)) then
+              print *, "WARNING: t_veg increment_factor is NaN at p=", p, " - leaving t_veg unchanged"
               t_update = t_veg(p)
             else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_veg(p) + increment_factor

--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -946,7 +946,8 @@ module enkf_clm_mod
         clm_statevec(cc+(1+nlevgrnd)*clm_varsize) = 0.0
         n_p = 0
         do p=clm_begp,clm_endp
-          if(patch%gridcell(p)==g) then
+          ! Skip bare-ground/lake patches where t_veg retains spval (1e36).
+          if(patch%gridcell(p)==g .and. t_veg(p) < 1.0e20_r8) then
             clm_statevec(cc+(1+nlevgrnd)*clm_varsize) = clm_statevec(cc+(1+nlevgrnd)*clm_varsize) + t_veg(p)
             n_p = n_p + 1
           end if
@@ -954,8 +955,8 @@ module enkf_clm_mod
         if(n_p > 0) then
           clm_statevec(cc+(1+nlevgrnd)*clm_varsize) = clm_statevec(cc+(1+nlevgrnd)*clm_varsize) / real(n_p, r8)
         else
-          write(*,*) "ERROR: Gridcell g=", g, " has no patches for TVEG averaging"
-          error stop "Gridcell without patches in set_clm_statevec_T (TVEG)"
+          ! No vegetated patches: reuse TSKIN mean as safe fallback.
+          clm_statevec(cc+(1+nlevgrnd)*clm_varsize) = clm_statevec(cc)
         end if
 
       end do
@@ -1357,6 +1358,10 @@ module enkf_clm_mod
     integer :: incr_warn_count_skin, incr_warn_count_soisno, &
                incr_warn_count_veg, incr_warn_count_grnd
 
+    ! Guard against applying t_soisno increment multiple times to the same
+    ! column when several patches share a column (T==2 loop is over patches).
+    logical, allocatable :: col_updated(:)
+
     ! LST
     t_grnd => temperature_inst%t_grnd_col
     t_soisno => temperature_inst%t_soisno_col
@@ -1374,6 +1379,9 @@ module enkf_clm_mod
     incr_warn_count_soisno  = 0
     incr_warn_count_veg     = 0
     incr_warn_count_grnd    = 0
+
+    allocate(col_updated(clm_begc:clm_endc))
+    col_updated = .false.
 
     !hcp: TG, TV
     if(clmupdate_T==1) then
@@ -1407,7 +1415,9 @@ module enkf_clm_mod
             t_update = t_skin(p) * increment_factor
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-            if (abs(increment_factor) < clmT_max_increment) then
+            if (ieee_is_nan(increment_factor)) then
+              t_update = t_skin(p)
+            else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_skin(p) + increment_factor
             else
               t_update = t_skin(p) + sign(clmT_max_increment, increment_factor)
@@ -1421,10 +1431,12 @@ module enkf_clm_mod
           if (ieee_is_nan(t_update)) then
             print *, "WARNING: t_skin update is NaN at p=", p
           else
-            t_skin(p) = t_update
+            t_skin(p) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
           end if
         end if
 
+        ! Guard: only update each column once even if multiple patches share it.
+        if (.not. col_updated(c)) then
         ! --- TSOIL: update with increment factor for each layer ---
         do lev=1,nlevgrnd
           cc = state_clm2pdaf_p(p, 1+lev)
@@ -1435,7 +1447,9 @@ module enkf_clm_mod
               t_update = t_soisno(c,lev) * increment_factor
             else
               increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-              if (abs(increment_factor) < clmT_max_increment) then
+              if (ieee_is_nan(increment_factor)) then
+                t_update = t_soisno(c,lev)
+              else if (abs(increment_factor) < clmT_max_increment) then
                 t_update = t_soisno(c,lev) + increment_factor
               else
                 t_update = t_soisno(c,lev) + sign(clmT_max_increment, increment_factor)
@@ -1449,21 +1463,25 @@ module enkf_clm_mod
             if (ieee_is_nan(t_update)) then
               print *, "WARNING: t_soisno update is NaN at c=", c, " lev=", lev
             else
-              t_soisno(c,lev) = t_update
+              t_soisno(c,lev) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
             end if
           end if
         end do
 
+        col_updated(c) = .true.
+        end if ! col_updated
         ! --- TVEG: update with increment factor ---
         cc = state_clm2pdaf_p(p, 2+nlevgrnd)
         ! Skip if no significant change in gridcell mean
-        if(abs(clm_statevec(cc) - clm_statevec_orig(cc)) > 1.0e-7) then
+        if(abs(clm_statevec(cc) - clm_statevec_orig(cc)) > 1.0e-7 .and. t_veg(p) < 1.0e20_r8) then
           if( (clmincrement_type == 0)) then
             increment_factor = clm_statevec(cc) / clm_statevec_orig(cc)
             t_update = t_veg(p) * increment_factor
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-            if (abs(increment_factor) < clmT_max_increment) then
+            if (ieee_is_nan(increment_factor)) then
+              t_update = t_veg(p)
+            else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_veg(p) + increment_factor
             else
               t_update = t_veg(p) + sign(clmT_max_increment, increment_factor)
@@ -1477,7 +1495,7 @@ module enkf_clm_mod
           if (ieee_is_nan(t_update)) then
             print *, "WARNING: t_veg update is NaN at p=", p
           else
-            t_veg(p) = t_update
+            t_veg(p) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
           end if
         end if
 
@@ -1488,6 +1506,7 @@ module enkf_clm_mod
       if (incr_warn_count_skin   > 0) print *, "WARNING: t_skin total increments exceeding T_max_increment:", incr_warn_count_skin
       if (incr_warn_count_soisno > 0) print *, "WARNING: t_soisno total increments exceeding T_max_increment:", incr_warn_count_soisno
       if (incr_warn_count_veg    > 0) print *, "WARNING: t_veg total increments exceeding T_max_increment:", incr_warn_count_veg
+      deallocate(col_updated)
     endif
 
     ! Skin temperature updating skin, soil, vegetation and ground temperature.

--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -1476,6 +1476,7 @@ module enkf_clm_mod
 
         col_updated(c) = .true.
         end if ! col_updated
+
         ! --- TVEG: update with increment factor ---
         cc = state_clm2pdaf_p(p, 2+nlevgrnd)
         ! Skip if no significant change in gridcell mean
@@ -1537,7 +1538,10 @@ module enkf_clm_mod
             t_update = t_skin(p) * increment_factor
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-            if (abs(increment_factor) < clmT_max_increment) then
+            if (ieee_is_nan(increment_factor)) then
+              print *, "WARNING: t_skin increment_factor is NaN at p=", p, " - leaving t_skin unchanged"
+              t_update = t_skin(p)
+            else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_skin(p) + increment_factor
             else
               t_update = t_skin(p) + sign(clmT_max_increment, increment_factor)
@@ -1547,10 +1551,12 @@ module enkf_clm_mod
           if (ieee_is_nan(t_update)) then
             print *, "WARNING: t_skin update is NaN at p=", p
           else
-            t_skin(p) = t_update
+            t_skin(p) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
           end if
         end if
 
+        ! Guard: only update each column once even if multiple patches share it.
+        if (.not. col_updated(c)) then
         ! --- TSOIL: update with increment factor for each layer ---
         do lev=1,nlevgrnd
           cc = state_clm2pdaf_p(p, 1+lev)
@@ -1561,7 +1567,10 @@ module enkf_clm_mod
               t_update = t_soisno(c,lev) * increment_factor
             else
               increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-              if (abs(increment_factor) < clmT_max_increment) then
+              if (ieee_is_nan(increment_factor)) then
+                print *, "WARNING: t_soisno increment_factor is NaN at c=", c, " lev=", lev, " - leaving t_soisno unchanged"
+                t_update = t_soisno(c,lev)
+              else if (abs(increment_factor) < clmT_max_increment) then
                 t_update = t_soisno(c,lev) + increment_factor
               else
                 t_update = t_soisno(c,lev) + sign(clmT_max_increment, increment_factor)
@@ -1571,21 +1580,25 @@ module enkf_clm_mod
             if (ieee_is_nan(t_update)) then
               print *, "WARNING: t_soisno update is NaN at c=", c, " lev=", lev
             else
-              t_soisno(c,lev) = t_update
+              t_soisno(c,lev) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
             end if
           end if
         end do
+        end if ! col_updated
 
         ! --- TVEG: update with increment factor ---
         cc = state_clm2pdaf_p(p, 2+nlevgrnd)
         ! Skip if no significant change in gridcell mean
-        if(abs(clm_statevec(cc) - clm_statevec_orig(cc)) > 1.0e-7) then
+        if(abs(clm_statevec(cc) - clm_statevec_orig(cc)) > 1.0e-7 .and. t_veg(p) < 1.0e20_r8) then
           if( (clmincrement_type == 0)) then
             increment_factor = clm_statevec(cc) / clm_statevec_orig(cc)
             t_update = t_veg(p) * increment_factor
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-            if (abs(increment_factor) < clmT_max_increment) then
+            if (ieee_is_nan(increment_factor)) then
+              print *, "WARNING: t_veg increment_factor is NaN at p=", p, " - leaving t_veg unchanged"
+              t_update = t_veg(p)
+            else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_veg(p) + increment_factor
             else
               t_update = t_veg(p) + sign(clmT_max_increment, increment_factor)
@@ -1595,10 +1608,12 @@ module enkf_clm_mod
           if (ieee_is_nan(t_update)) then
             print *, "WARNING: t_veg update is NaN at p=", p
           else
-            t_veg(p) = t_update
+            t_veg(p) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
           end if
         end if
 
+        ! Guard: only update each column once even if multiple patches share it.
+        if (.not. col_updated(c)) then
         ! --- TGRND: update with increment factor ---
         cc = state_clm2pdaf_p(p, 3+nlevgrnd)
         ! Skip if no significant change in gridcell mean
@@ -1608,7 +1623,10 @@ module enkf_clm_mod
             t_update = t_grnd(c) * increment_factor
           else
             increment_factor = clm_statevec(cc) - clm_statevec_orig(cc)
-            if (abs(increment_factor) < clmT_max_increment) then
+            if (ieee_is_nan(increment_factor)) then
+              print *, "WARNING: t_grnd increment_factor is NaN at c=", c, " - leaving t_grnd unchanged"
+              t_update = t_grnd(c)
+            else if (abs(increment_factor) < clmT_max_increment) then
               t_update = t_grnd(c) + increment_factor
             else
               t_update = t_grnd(c) + sign(clmT_max_increment, increment_factor)
@@ -1618,9 +1636,12 @@ module enkf_clm_mod
           if (ieee_is_nan(t_update)) then
             print *, "WARNING: t_grnd update is NaN at c=", c
           else
-            t_grnd(c) = t_update
+            t_grnd(c) = max(SHR_CONST_TKFRZ - 130.0_r8, min(SHR_CONST_TKFRZ + 100.0_r8, t_update))
           end if
         end if
+
+        col_updated(c) = .true.
+        end if ! col_updated
 
         end if mask_freeze_2
         end if mask_snow_2
@@ -1634,6 +1655,7 @@ module enkf_clm_mod
         incr_warn_count_veg
       if (incr_warn_count_grnd   > 0) print *, "WARNING: t_grnd total increments exceeding T_max_increment:", &
         incr_warn_count_grnd
+      deallocate(col_updated)
     endif
 
 #ifdef PDAF_DEBUG


### PR DESCRIPTION
Problem: NaN values to coupler after about 1 year of eCLM simulation with LSTDA.

Goal: Introduce more checks to the LSTDA-update


remark: co-authored by Claude-Code

## Summary

  1. `spval filter on t_veg`: Excludes non-vegetated patches (t_veg = 1e36) from  
  TVEG averaging and updates. Falls back to TSKIN mean for fully non-vegetated
  gridcells instead of crashing.                                                
  2. `Per-column update guard (col_updated)`: Prevents TSOIL increments from being
   applied multiple times to the same column when multiple patches share it.
  3. `NaN check on increment_factor`: Fortran's abs(NaN) < threshold silently
  evaluates to .false., bypassing the cap. An explicit ieee_is_nan guard leaves
  the variable unchanged instead.
  4. `Temperature clamp [TKFRZ−130, TKFRZ+100]`: Last-resort physical bounds check
   on all updated temperatures.