### PR TITLE
Fix divide-by-zero in domain_def_clm for degenerate 1x1 domains

### DIFF
--- a/interface/model/eclm/enkf_clm_mod_5.F90
+++ b/interface/model/eclm/enkf_clm_mod_5.F90
@@ -1313,6 +1313,8 @@ module enkf_clm_mod
     integer :: ncols, counter
     integer :: npatches, ncohorts
     real :: minlon, minlat, maxlon, maxlat
+    real(r8) :: dlon_span, dlat_span
+    real(r8), parameter :: tol_degen = 1.0e-6_r8 
     real(r8), pointer :: lon(:)
     real(r8), pointer :: lat(:)
     integer :: begg, endg   ! per-proc gridcell ending gridcell indices
@@ -1371,6 +1373,11 @@ module enkf_clm_mod
     maxlon = MAXVAL(lon(:) + 180)
     minlat = MINVAL(lat(:) + 90)
     maxlat = MAXVAL(lat(:) + 90)
+    
+    ! Degenerate horizontal domain (e.g. 1x1 grid): min==max => zero span; 
+    ! Avoid dividing by (maxlon-minlon) or (maxlat-minlat). 
+    dlon_span = maxval(lon(:) + 180._r8) - minval(lon(:) + 180._r8)
+    dlat_span = maxval(lat(:) + 90._r8) - minval(lat(:) + 90._r8)
 
     if(allocated(longxy_obs)) deallocate(longxy_obs)
     allocate(longxy_obs(dim_obs), stat=ier)
@@ -1378,7 +1385,16 @@ module enkf_clm_mod
     allocate(latixy_obs(dim_obs), stat=ier)
 
     do i = 1, dim_obs
-       if(((lon_clmobs(i) + 180) - minlon) /= 0 .and. &
+       if (dlon_span <= tol_degen .and. dlat_span <= tol_degen) then
+          longxy_obs(i) = 1
+          latixy_obs(i) = 1
+       else if (dlon_span <= tol_degen) then
+          longxy_obs(i) = 1
+          latixy_obs(i) = ceiling(((lat_clmobs(i) + 90) - minlat) * nj / (maxlat - minlat))
+       else if (dlat_span <= tol_degen) then
+          longxy_obs(i) = ceiling(((lon_clmobs(i) + 180) - minlon) * ni / (maxlon - minlon))
+          latixy_obs(i) = 1
+       else if(((lon_clmobs(i) + 180) - minlon) /= 0 .and. &
          ((lat_clmobs(i) + 90) - minlat) /= 0) then
           longxy_obs(i) = ceiling(((lon_clmobs(i) + 180) - minlon) * ni / (maxlon - minlon)) !+ 1
           latixy_obs(i) = ceiling(((lat_clmobs(i) + 90) - minlat) * nj / (maxlat - minlat)) !+ 1
@@ -1395,6 +1411,7 @@ module enkf_clm_mod
           latixy_obs(i) = 1
        endif
     end do
+    
     ! deallocate temporary arrays
     !deallocate(longxy)
     !deallocate(latixy)


### PR DESCRIPTION
**Bug:** TSMP-PDAF crashes during CLM observation setup with a floating-point exception (divide by zero) in domain_def_clm (enkf_clm_mod_5.F90), e.g. when calling init_dim_obs_pdaf → domain_def_clm, see: https://github.com/HPSCTerrSys/pdaf/issues/64

**Cause:**  For a single land grid cell (1×1 domain), minlon == maxlon and minlat == maxlat after shifting by +180° / +90°, so (maxlon - minlon) and (maxlat - minlat) are zero. The code then maps observation lon/lat to grid indices by dividing by those spans. When observation coordinates differ slightly from the grid (e.g. float32 in NetCDF vs. double lonc/latc), the first branch can still be taken and divide by zero.

**Fix:**  Compute longitudinal and latitudinal spans in real(r8) and treat the domain as degenerate when span ≤ 1.0e-6 (same units as lon+180 / lat+90). 