### PR TITLE
OMI: Observation input `dr`: Array of Length 2 in observation file

### DIFF
--- a/docs/users_guide/running_tsmp_pdaf/input_obs.md
+++ b/docs/users_guide/running_tsmp_pdaf/input_obs.md
@@ -273,14 +273,9 @@ Each of the CLM observations is snapped to the nearest CLM grid cell
 based on the given `lon`, `lat` and the snapping distance `dr` which
 should be smaller than the minimum grid cell size.
 
-**Attention (non-OMI)** This variable should have a length of `2` (one
-snapping distance in longitude direction and another snapping distance
-in latitude direction).
-
-**Attention (OMI)** in OMI `dr` is currently read as `dim=dim_obs` and
-used as length `1` (only the first element, used for both longitude
-direction and latitude direction). See [PDAF with
-OMI](omi:tsmp-pdaf-with-pdaf-omi).
+This variable should have a length of `2` (one snapping distance in
+longitude direction and another snapping distance in latitude
+direction).
 
 (obs:files:clm:typeclm)=
 #### type_clm ####

--- a/docs/users_guide/running_tsmp_pdaf/tsmp_pdaf_omi.md
+++ b/docs/users_guide/running_tsmp_pdaf/tsmp_pdaf_omi.md
@@ -19,24 +19,20 @@ If questions arise contact ewerdwalbesloh@geod.uni-bonn.de
 The reader `read_obs_nc_type` expects the following variables in each
 observation file:
 
-| NetCDF name  | Type                                               | Required?       |
-|--------------|----------------------------------------------------|-----------------|
-| `dim_obs`    | dimension                                          | yes             |
-| `obs_clm`    | `REAL(dim_obs)`                                    | yes             |
-| `type_clm`   | `CHARACTER(20)(dim_obs)`                           | yes             |
-| `lon`        | `REAL(dim_obs)`                                    | yes             |
-| `lat`        | `REAL(dim_obs)`                                    | yes             |
-| `layer`      | `INTEGER(dim_obs)`                                 | yes             |
-| `dr`         | read from netCDF: `REAL(dim_obs)`, used: `REAL(1)` | yes             |
-| `obserr_clm` | `REAL(dim_obs)`                                    | if `multierr=1` |
-| `obscov_clm` | `REAL(dim_obs,dim_obs)`                            | if `multierr=2` |
+| NetCDF name  | Type                     | Required?       |
+|--------------|--------------------------|-----------------|
+| `dim_obs`    | dimension                | yes             |
+| `obs_clm`    | `REAL(dim_obs)`          | yes             |
+| `type_clm`   | `CHARACTER(20)(dim_obs)` | yes             |
+| `lon`        | `REAL(dim_obs)`          | yes             |
+| `lat`        | `REAL(dim_obs)`          | yes             |
+| `layer`      | `INTEGER(dim_obs)`       | yes             |
+| `dr`         | `REAL(2)`                | yes             |
+| `obserr_clm` | `REAL(dim_obs)`          | if `multierr=1` |
+| `obscov_clm` | `REAL(dim_obs,dim_obs)`  | if `multierr=2` |
 
 Files follow the naming convention `<obs_filename>.<NNNNN>`
 (five-digit zero-padded PDAF step).
-
-**Note** on `dr`: For non-OMI, this array has length `2`, but in OMI
-it is read in `mod_read_obs` as length `dim_obs` and then only the
-first element is used.
 
 The [`type_clm`](obs:files:clm:typeclm) field must be homogeneous
 within a file - a file containing GRACE observations cannot

--- a/interface/framework/mod_read_obs.F90
+++ b/interface/framework/mod_read_obs.F90
@@ -180,7 +180,7 @@ contains
             allocate(layer_obs_g(dim_obs))
 
             if(allocated(dr_obs_g))   deallocate(dr_obs_g)
-            allocate(dr_obs_g(dim_obs))
+            allocate(dr_obs_g(2))
 
             call check(nf90_get_var(ncid, clmobs_varid, obs_g))
 

--- a/interface/framework/obs_SM_pdafomi.F90
+++ b/interface/framework/obs_SM_pdafomi.F90
@@ -349,7 +349,7 @@ MODULE obs_SM_pdafomi
         if(allocated(lat_obs)) deallocate(lat_obs)
         allocate(lat_obs(dim_obs))
         if(allocated(dr_obs)) deallocate(dr_obs)
-        allocate(dr_obs(dim_obs))
+        allocate(dr_obs(2))
         if(allocated(layer_obs)) deallocate(layer_obs)
         allocate(layer_obs(dim_obs))
         if(multierr==1) then
@@ -362,7 +362,7 @@ MODULE obs_SM_pdafomi
       if(multierr==1) call mpi_bcast(obserr, dim_obs, MPI_DOUBLE_PRECISION, 0, comm_filter, ierror)
       call mpi_bcast(lon_obs, dim_obs, MPI_DOUBLE_PRECISION, 0, comm_filter, ierror)
       call mpi_bcast(lat_obs, dim_obs, MPI_DOUBLE_PRECISION, 0, comm_filter, ierror)
-      call mpi_bcast(dr_obs,  dim_obs, MPI_DOUBLE_PRECISION, 0, comm_filter, ierror)
+      call mpi_bcast(dr_obs,  2      , MPI_DOUBLE_PRECISION, 0, comm_filter, ierror)
       call mpi_bcast(layer_obs, dim_obs, MPI_INTEGER, 0, comm_filter, ierror)
 
 
@@ -434,7 +434,7 @@ MODULE obs_SM_pdafomi
 
               ! Assigning observations to grid cells according to
               ! snapping distance or index arrays
-              if(((is_use_dr).and.(deltax<=dr_obs(1)).and.(deltay<=dr_obs(1))).or. &
+              if(((is_use_dr).and.(deltax<=dr_obs(1)).and.(deltay<=dr_obs(2))).or. &
                  ((.not. is_use_dr).and.(longxy_obs(i) == longxy(cnt)) .and. &
                   (latixy_obs(i) == latixy(cnt)))) then
 
@@ -619,7 +619,7 @@ MODULE obs_SM_pdafomi
                   deltay = abs(lat(g)-lat_obs(i))
                 end if
 
-                if(((is_use_dr).and.(deltax<=dr_obs(1)).and.(deltay<=dr_obs(1))).or. &
+                if(((is_use_dr).and.(deltax<=dr_obs(1)).and.(deltay<=dr_obs(2))).or. &
                    ((.not. is_use_dr).and.(longxy_obs(i) == longxy(g-begg+1)) .and. &
                     (latixy_obs(i) == latixy(g-begg+1)))) then
 #ifdef CLMFIVE
@@ -712,7 +712,7 @@ MODULE obs_SM_pdafomi
                 deltay = abs(lat(g)-lat_obs(i))
               end if
 
-              if(((is_use_dr).and.(deltax<=dr_obs(1)).and.(deltay<=dr_obs(1))).or. &
+              if(((is_use_dr).and.(deltax<=dr_obs(1)).and.(deltay<=dr_obs(2))).or. &
                  ((.not. is_use_dr).and.(longxy_obs(i) == longxy(g-begg+1)) .and. &
                   (latixy_obs(i) == latixy(g-begg+1)))) then
                 ! if haversine formula in distance calculation, the coordinates have to be converted to radians


### PR DESCRIPTION
Main reason: Make observation files usable for OMI and non-OMI simulations.