### PR TITLE
Fix: correct longitude distance calculation for snapping radius

### DIFF
--- a/interface/framework/obs_SM_pdafomi.F90
+++ b/interface/framework/obs_SM_pdafomi.F90
@@ -424,10 +424,9 @@ MODULE obs_SM_pdafomi
             if(newgridcell) then
 
               if(is_use_dr) then
-                  if (lon(g)>180) then
-                    deltax = abs(lon(g)-lon_obs(i)-360)
-                  else
-                    deltax = abs(lon(g)-lon_obs(i))
+                  deltax = abs(lon(g)-lon_obs(i))
+                  if (deltax > 180.0) then
+                    deltax = 360.0 - deltax
                   end if
                   deltay = abs(lat(g)-lat_obs(i))
               end if
@@ -611,10 +610,9 @@ MODULE obs_SM_pdafomi
               if(newgridcell) then
 
                 if(is_use_dr) then
-                  if (lon(g)>180) then
-                    deltax = abs(lon(g)-lon_obs(i)-360)
-                  else
-                    deltax = abs(lon(g)-lon_obs(i))
+                  deltax = abs(lon(g)-lon_obs(i))
+                  if (deltax > 180.0) then
+                    deltax = 360.0 - deltax
                   end if
                   deltay = abs(lat(g)-lat_obs(i))
                 end if
@@ -704,10 +702,9 @@ MODULE obs_SM_pdafomi
             if(newgridcell) then
 
               if(is_use_dr) then
-                if (lon(g)>180) then
-                  deltax = abs(lon(g)-lon_obs(i)-360)
-                else
-                  deltax = abs(lon(g)-lon_obs(i))
+                deltax = abs(lon(g)-lon_obs(i))
+                if (deltax > 180.0) then
+                  deltax = 360.0 - deltax
                 end if
                 deltay = abs(lat(g)-lat_obs(i))
               end if


### PR DESCRIPTION
The previous logic in `obs_SM_pdafomi` produced a wrong `deltax` whenever both model and observation longitudes exceeded 180 deg.

Replaced with shortest-arc formula from `obs_LST_pdafomi`: compute the absolute difference and wrap it by subtracting from 360 if it exceeds 180.

Found by: @visakhraja 