### PR TITLE
eCLM-PDAF: Error message as multiple observation types require OMI

### DIFF
--- a/interface/framework/init_pdaf.F90
+++ b/interface/framework/init_pdaf.F90
@@ -345,6 +345,26 @@ SUBROUTINE init_pdaf()
 
   IF (mype_world == 0) call init_pdaf_info()
 
+#if defined CLMSA
+#ifdef CLMFIVE
+! *** Check: multiple eCLM update types without OMI will cause incorrect obs operator ***
+  IF (.NOT. use_omi) THEN
+    IF (  (clmupdate_swc /= 0 .AND. clmupdate_tws /= 0) &
+         ) THEN
+      IF (mype_world == 0) THEN
+        WRITE(*,"(/a)") "ERROR (init_pdaf): Multiple eCLM update types are active but use_omi is not set."
+        WRITE(*,"(a,i0)") "       clmupdate_swc = ", clmupdate_swc
+        WRITE(*,"(a,i0)") "       clmupdate_tws = ", clmupdate_tws
+        WRITE(*,"(a)")    "       Multi-observation assimilation requires the OMI interface."
+        WRITE(*,"(a)")    "       Add `-use_omi .true.` to the tsmp-pdaf command line execution."
+      END IF
+      CALL abort_parallel()
+    END IF
+  END IF
+#endif
+#endif
+
+
 ! *** Switch on debug output ***
 ! *** for main process        ***
 #ifdef PDAF_DEBUG


### PR DESCRIPTION
Prevent non-OMI simulations with multiple observation types turned on to run into hard-to-understand runtime errors (e.g. segmentation faults because of wrong indexing)